### PR TITLE
Update and improve old userscript

### DIFF
--- a/fc_userscript_loader.user.js
+++ b/fc_userscript_loader.user.js
@@ -1,25 +1,26 @@
 // ==UserScript==
 // @name           Frozen Cookies
 // @version        github-latest
-// @description    Userscript to load Frozen Cookies written by Icehawk78
+// @description    Userscript to load Frozen Cookies written by Icehawk78, forked by haerik
 // @author         shinji257
 // @homepage       https://github.com/Icehawk78/FrozenCookies
 // @include        http://orteil.dashnet.org/cookieclicker/
-// @updateURL      http://icehawk78.github.io/FrozenCookies/fc_userscript_loader.js
-// @downloadURL    http://icehawk78.github.io/FrozenCookies/fc_userscript_loader.js
+// @updateURL      https://rawgithub.com/haerik/FrozenCookies/master/fc_userscript_loader.js
+// @downloadURL    https://rawgithub.com/haerik/FrozenCookies/master/fc_userscript_loader.js
+// @run-at         document-start
 // ==/UserScript==
 
 // Dev:       https://raw.github.com/Icehawk78/FrozenCookies/development/
 // Master:    https://raw.github.com/Icehawk78/FrozenCookies/master/
 // Github.io: http://icehawk78.github.io/FrozenCookies/
+// Change URL to point to haerik's fork... remove download/update urls...
 
 function LoadFrozenCookies() {
   var js = document.createElement('script');
   js.setAttribute('type', 'text/javascript');
   js.setAttribute('id', 'frozenCookieScript');
-  js.setAttribute('src', 'https://raw.github.com/Icehawk78/FrozenCookies/master/frozen_cookies.js');
+  js.setAttribute('src', 'https://rawgithub.com/haerik/FrozenCookies/master/frozen_cookies.js');
   document.head.appendChild(js);
 }
-// It's not the best way but Chrome doesn't work with addEventListener... :(
-// Delay load by 5 seconds to allow the site to load itself first.)
-window.setTimeout(LoadFrozenCookies, 5000);
+
+window.addEventListener("load", LoadFrozenCookies, false);


### PR DESCRIPTION
So 3 years ago I wrote the user script to auto load Frozen Cookies but at the time I had to resort to setTimeout due to issues getting addEventListener.  I finally came around to even looking at it again (I took a 2 and a half year break from cookie clicker) and got it to work properly after a bit of research using @run-at so that it gets timed correctly.  Now it will wait until the document has loaded and won't be held back by an arbitrary timeout for those on fast connections.

* Point load url to haerik's fork
* change setTimeout to addEventListener
* Use @run-at to get it to load at an appropriate timeframe so that the above change can actually work.  Seems to work consistently.  Tested in Chrome using Tampermonkey and Firefox using Greasemonkey