### PR TITLE
script loading improvements

### DIFF
--- a/frozen_cookies.js
+++ b/frozen_cookies.js
@@ -1,5 +1,7 @@
 // Global Variables
-var scriptElement = document.getElementById( 'frozenCookieScript' ),
+var scriptElement = document.getElementById('frozenCookieScript') != null ?
+		document.getElementById('frozenCookieScript') : 
+		document.getElementById('modscript_frozen_cookies'),
 	baseUrl = scriptElement !== null ?
 		scriptElement.getAttribute('src').replace(/\/frozen_cookies\.js$/, '') :
 		'https://cdn.rawgit.com/haerik/FrozenCookies/master',

--- a/frozen_cookies.js
+++ b/frozen_cookies.js
@@ -4,7 +4,7 @@ var scriptElement = document.getElementById('frozenCookieScript') != null ?
 		document.getElementById('modscript_frozen_cookies'),
 	baseUrl = scriptElement !== null ?
 		scriptElement.getAttribute('src').replace(/\/frozen_cookies\.js$/, '') :
-		'https://cdn.rawgit.com/haerik/FrozenCookies/master',
+		'https://rawgit.com/haerik/FrozenCookies/master',
 	FrozenCookies = {
 		'baseUrl': baseUrl,
 		'branch' : 'Beta-',

--- a/frozen_cookies.js
+++ b/frozen_cookies.js
@@ -1,5 +1,5 @@
 // Global Variables
-var scriptElement = document.getElementById('frozenCookieScript') != null ?
+var scriptElement = document.getElementById('frozenCookieScript') !== null ?
 		document.getElementById('frozenCookieScript') : 
 		document.getElementById('modscript_frozen_cookies'),
 	baseUrl = scriptElement !== null ?


### PR DESCRIPTION
this pull request improves script loading for those users that are invoking the mod through Cookie Clicker's official userscript loading method Game.LoadMod('https://rawgit.com/haerik/FrozenCookies/master/frozen_cookies.js'); - the changes ensures that additional assets like main.js are loaded from the correct baseUrl. with the change, it is now possible to correctly different branches and repositories, for example Game.LoadMod('https://rawgit.com/myname/FrozenCookies/mycoolnewfeaturebranch/frozen_cookies.js'); 