### PR TITLE
initial simple Season autobuy

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -921,7 +921,7 @@ function upgradeStats(recalculate) {
         Game.elderWrath = existingWrath;
         var deltaCps = cpsNew - cpsOrig;
         var baseDeltaCps = baseCpsNew - baseCpsOrig;
-        var efficiency = (priceReduction > cost) ? 1 : purchaseEfficiency(cost, deltaCps, baseDeltaCps, cpsOrig)
+        var efficiency = (current.season) ? (current.season == "fools" ? 1e-254 : 1e-255) : (priceReduction > cost) ? 1 : purchaseEfficiency(cost, deltaCps, baseDeltaCps, cpsOrig);
         return {'id' : current.id, 'efficiency' : efficiency, 'base_delta_cps' : baseDeltaCps, 'delta_cps' : deltaCps, 'cost' : cost, 'purchase' : current, 'type' : 'upgrade'};
       }
     }).filter(function(a){return a;});
@@ -937,7 +937,7 @@ function isUnavailable(upgrade, upgradeBlacklist) {
   result = result || (upgradeBlacklist === true);
   result = result || _.contains(upgradeBlacklist, upgrade.id);
   result = result || (needed && _.find(needed, function(a){return a.type == "wrinklers"}) != null);
-  result = result || (upgrade.season && !haveAll(Game.season));
+  result = result || (upgrade.season && (!haveAll(Game.season) || (upgrade.season != "fools" && haveAll(upgrade.season))));
 
   if (upgrade.id == 331) {
     result = true; // blacklist golden switch from being used, until proper logic can be implemented

--- a/frozen_cookies.js
+++ b/frozen_cookies.js
@@ -1,5 +1,7 @@
 // Global Variables
-var scriptElement = document.getElementById( 'frozenCookieScript' ),
+var scriptElement = document.getElementById('frozenCookieScript') != null ?
+		document.getElementById('frozenCookieScript') : 
+		document.getElementById('modscript_frozen_cookies'),
 	baseUrl = scriptElement !== null ?
 		scriptElement.getAttribute('src').replace(/\/frozen_cookies\.js$/, '') :
 		'https://cdn.rawgit.com/haerik/FrozenCookies/master',

--- a/frozen_cookies.js
+++ b/frozen_cookies.js
@@ -4,7 +4,7 @@ var scriptElement = document.getElementById('frozenCookieScript') != null ?
 		document.getElementById('modscript_frozen_cookies'),
 	baseUrl = scriptElement !== null ?
 		scriptElement.getAttribute('src').replace(/\/frozen_cookies\.js$/, '') :
-		'https://cdn.rawgit.com/haerik/FrozenCookies/master',
+		'https://rawgit.com/haerik/FrozenCookies/master',
 	FrozenCookies = {
 		'baseUrl': baseUrl,
 		'branch' : 'Beta-',

--- a/frozen_cookies.js
+++ b/frozen_cookies.js
@@ -1,5 +1,5 @@
 // Global Variables
-var scriptElement = document.getElementById('frozenCookieScript') != null ?
+var scriptElement = document.getElementById('frozenCookieScript') !== null ?
 		document.getElementById('frozenCookieScript') : 
 		document.getElementById('modscript_frozen_cookies'),
 	baseUrl = scriptElement !== null ?


### PR DESCRIPTION
this pull request allows basic season autobuying. seasons with upgrades (eggs/cookies) are preferred until all upgrades are found, then "Business Day" season is kept active to profit from its golden cookie prestige upgrade. 

to enable autobuying the season toggles the purchase efficiency has to be faked. maybe someone comes up with a more sensible calculation - my goal was to prefer the season toggles before any other upgrades. the current method seems to work pretty well for endgame playmode. I have tested it on my 16 day nonstop play run as well as some quick ascension runs.

some future ideas built on this might include:
- set an optimal season order (f.e. valentines -> christmas -> easter -> halloween -> business day)
- season blacklist
- only keep business day active if the "Startrade" prestige upgrade has been actually bought
- do not buy "Elders Pledge" when season cookies/eggs are missing