### PR TITLE
fix seasons having too low efficiency

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -921,7 +921,7 @@ function upgradeStats(recalculate) {
         Game.elderWrath = existingWrath;
         var deltaCps = cpsNew - cpsOrig;
         var baseDeltaCps = baseCpsNew - baseCpsOrig;
-        var efficiency = (current.season && current.season == seasons[FrozenCookies.defaultSeason]) ? cost/baseCpsOrig : (priceReduction > cost) ? 1 : purchaseEfficiency(cost, deltaCps, baseDeltaCps, cpsOrig);
+        var efficiency = (current.season) ? (current.season == seasons[FrozenCookies.defaultSeason] ? 1e-254 : (current.season == "fools" ? 1e-253 : 1e-255)) : (priceReduction > cost) ? 1 : purchaseEfficiency(cost, deltaCps, baseDeltaCps, cpsOrig);
         return {'id' : current.id, 'efficiency' : efficiency, 'base_delta_cps' : baseDeltaCps, 'delta_cps' : deltaCps, 'cost' : cost, 'purchase' : current, 'type' : 'upgrade'};
       }
     }).filter(function(a){return a;});


### PR DESCRIPTION
the change will make FrozenCookies prefer buying a season at the earliest possible point before buying other upgrade items. additionally, the "fools" season should be switched to last as it does not have eggs or upgrades.

the proposed change enforces the following preference order:
1. any season with upgrades except "fools"
2. defaultSeason
3. "fools" season
4. other items